### PR TITLE
Add charts, md docs, helm build scripts

### DIFF
--- a/.github/workflows/helm-chart-build.yml
+++ b/.github/workflows/helm-chart-build.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - '*'
 
+permissions:
+  packages: write
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-chart-build.yml
+++ b/.github/workflows/helm-chart-build.yml
@@ -1,0 +1,46 @@
+name: Build and Publish Helm Charts
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v3
+      with:
+        version: v3.12.3  # nebo nejnovější stabilní verzi
+
+    - name: Package Helm Charts
+      run: |
+        cd charts
+        for chart in ./*; do
+          if [ -f "$chart/Chart.yaml" ]; then
+            helm dependency update "$chart"
+            helm package "$chart"
+          fi
+        done
+
+    - name: Update Helm Repository Index
+      run: |
+        helm repo index charts --url https://k0rdent.github.io/catalog/charts
+
+    - name: Remove .gitignore to include generated files to gh-pages
+      run: |
+        rm -f .gitignore
+
+    - name: Publish to "gh-pages" branch
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: charts
+        destination_dir: charts

--- a/.github/workflows/helm-chart-build.yml
+++ b/.github/workflows/helm-chart-build.yml
@@ -1,10 +1,8 @@
-name: Build and Publish Helm Charts
+name: Build and Publish Helm Charts to GHCR
 
 on:
   push:
     branches:
-      - main
-    tags:
       - '*'
 
 jobs:
@@ -18,29 +16,27 @@ jobs:
     - name: Set up Helm
       uses: azure/setup-helm@v3
       with:
-        version: v3.12.3  # nebo nejnovější stabilní verzi
+        version: v3.12.3
 
-    - name: Package Helm Charts
+    - name: Log in to GitHub Container Registry
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
+
+    - name: Build and Push Helm Charts
       run: |
+        # Lowercase the GHCR path
+        GHCR_PATH="$(echo "ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}/charts" | tr '[:upper:]' '[:lower:]')"
         cd charts
         for chart in ./*; do
-          if [ -f "$chart/Chart.yaml" ]; then
-            helm dependency update "$chart"
-            helm package "$chart"
+          VERSION=$(awk '/^version:/ {print $2}' "$chart/Chart.yaml")
+          if [ "${GITHUB_REF_NAME}" != "${{ github.event.repository.default_branch }}" ]; then
+            VERSION="$VERSION-${GITHUB_REF_NAME//\//-}"
           fi
+
+          # Update Helm chart dependencies, then package
+          helm dependency update "$chart"
+          helm package "$chart" --version "$VERSION"
+          PACKAGE_FILE="$chart-$VERSION.tgz"
+
+          echo "Pushing $PACKAGE_FILE to oci://$GHCR_PATH"
+          helm push "$PACKAGE_FILE" "oci://$GHCR_PATH"
         done
-
-    - name: Update Helm Repository Index
-      run: |
-        helm repo index charts --url https://k0rdent.github.io/catalog/charts
-
-    - name: Remove .gitignore to include generated files to gh-pages
-      run: |
-        rm -f .gitignore
-
-    - name: Publish to "gh-pages" branch
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: charts
-        destination_dir: charts

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+charts/*/charts/*.tgz
+charts/*.tgz
+charts/index.yaml

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
-# catalog
-k0rdent templates catalog
+# k0rdent service templates
+[k0rdent](https://k0rdent.github.io/docs/) supported service templates.
+
+For testing you can use [k0rdent demo setup](https://github.com/k0rdent/demos?tab=readme-ov-file#demo-cluster-setup).
+
+## Setup k0rdent-catalog helm repository
+Setup extra helm repository and service templates using prepared manifests:
+~~~bash
+kubectl apply -f manifests/setup # Configure a new k0rdent helm repository and service templates
+kubectl get helmrepositories -A # Check repository was successfully added
+kubectl get servicetemplate -A # Check service templates
+~~~
+
+## Use it in managed cluster(s)
+
+### Using MultiClusterService
+~~~bash
+kubectl apply -f manifests/global-nginx-ingress-f5.yaml
+kubectl apply -f manifests/global-dapr.yaml
+kubectl get multiclusterservices
+# NAME             AGE
+# global-dapr      9m27s
+~~~
+
+### Using ClusterDeployment
+Update your managed cluster manifest `spec.services` section, e.g.:
+~~~yaml
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: ClusterDeployment
+# ...
+spec:
+  services:
+    - template: dapr-1-14-4
+      name: managed-dapr
+      namespace: dapr-system
+# ...
+~~~

--- a/charts/dapr/Chart.lock
+++ b/charts/dapr/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: dapr
+  repository: https://dapr.github.io/helm-charts/
+  version: 1.14.4
+- name: dapr-dashboard
+  repository: https://dapr.github.io/helm-charts/
+  version: 0.15.0
+digest: sha256:750299d32615a12e0fef46fe5ffc1a7b45ec22c08fcac9016b8a0ee99377efef
+generated: "2025-01-21T12:13:48.861033+01:00"

--- a/charts/dapr/Chart.yaml
+++ b/charts/dapr/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: dapr
+description: A Helm chart to refer the official dapr helm chart
+type: application
+version: 1.14.4
+appVersion: "1.14.4"
+dependencies:
+  - name: dapr
+    version: 1.14.4
+    repository: https://dapr.github.io/helm-charts/
+  - name: dapr-dashboard
+    version: 0.15.0
+    repository: https://dapr.github.io/helm-charts/

--- a/charts/nginx-ingress-f5/Chart.lock
+++ b/charts/nginx-ingress-f5/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: nginx-ingress
+  repository: oci://ghcr.io/nginxinc/charts
+  version: 2.0.0
+digest: sha256:f6c441acfa9034cf96d3c773003b97fba5215063139430ce8c57118beedd3e4f
+generated: "2025-01-21T12:52:18.512065+01:00"

--- a/charts/nginx-ingress-f5/Chart.yaml
+++ b/charts/nginx-ingress-f5/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: nginx-ingress-f5
+description: A Helm chart to refer the official F5 nginx-ingress helm chart
+type: application
+version: 2.0.0
+appVersion: "2.0.0"
+dependencies:
+  - name: nginx-ingress
+    version: 2.0.0
+    repository: oci://ghcr.io/nginxinc/charts

--- a/charts/tetrate-istio/Chart.lock
+++ b/charts/tetrate-istio/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: base
+  repository: https://tis.tetrate.io/charts
+  version: 1.24.20001
+- name: istiod
+  repository: https://tis.tetrate.io/charts
+  version: 1.24.20001
+digest: sha256:0a192b6f74ef1e45aee52bd5263a94041c0a4f3445f4a2460aec9b6fa08fd44f
+generated: "2025-01-22T13:58:39.659334+01:00"

--- a/charts/tetrate-istio/Chart.yaml
+++ b/charts/tetrate-istio/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: tetrate-istio
+description: A Helm chart to refer the official Tetrate Istio helm charts
+type: application
+version: 1.24.20001
+appVersion: "1.24.2-tetrate1"
+dependencies:
+  - name: base
+    version: 1.24.20001
+    repository: https://tis.tetrate.io/charts
+  - name: istiod
+    version: 1.24.20001
+    repository: https://tis.tetrate.io/charts

--- a/manifests/global-dapr.yaml
+++ b/manifests/global-dapr.yaml
@@ -1,0 +1,14 @@
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: MultiClusterService
+metadata:
+  name: global-dapr
+spec:
+  clusterSelector:
+    matchLabels:
+      k0rdent: demo
+  serviceSpec:
+    priority: 1000
+    services:
+      - template: dapr-1-14-4
+        name: managed-dapr
+        namespace: dapr-system

--- a/manifests/global-nginx-ingress-f5.yaml
+++ b/manifests/global-nginx-ingress-f5.yaml
@@ -1,0 +1,14 @@
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: MultiClusterService
+metadata:
+  name: global-nginx-ingress-f5
+spec:
+  clusterSelector:
+    matchLabels:
+      k0rdent: demo
+  serviceSpec:
+    priority: 1000
+    services:
+      - template: nginx-ingress-f5-2-0-0
+        name: managed-nginx-ingress-f5
+        namespace: nginx-ingress-f5

--- a/manifests/setup/01-helm_repo.yaml
+++ b/manifests/setup/01-helm_repo.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     k0rdent.mirantis.com/managed: "true"
 spec:
-  interval: 10m0s
-  url: https://k0rdent.github.io/catalog/charts/
+  type: oci
+  url: oci://ghcr.io/k0rdent/catalog/charts

--- a/manifests/setup/01-helm_repo.yaml
+++ b/manifests/setup/01-helm_repo.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: k0rdent-catalog
+  namespace: k0rdent
+  labels:
+    k0rdent.mirantis.com/managed: "true"
+spec:
+  interval: 10m0s
+  url: https://k0rdent.github.io/catalog/charts/

--- a/manifests/setup/02-service-template-dapr.yaml
+++ b/manifests/setup/02-service-template-dapr.yaml
@@ -1,0 +1,14 @@
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: ServiceTemplate
+metadata:
+  name: dapr-1-14-4
+  namespace: k0rdent
+spec:
+  helm:
+    chartSpec:
+      chart: dapr
+      version: 1.14.4
+      interval: 10m0s
+      sourceRef:
+        kind: HelmRepository
+        name: k0rdent-catalog

--- a/manifests/setup/03-service-template-nginx-ingress-f5.yaml
+++ b/manifests/setup/03-service-template-nginx-ingress-f5.yaml
@@ -1,0 +1,14 @@
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: ServiceTemplate
+metadata:
+  name: nginx-ingress-f5-2-0-0
+  namespace: k0rdent
+spec:
+  helm:
+    chartSpec:
+      chart: nginx-ingress-f5
+      version: 2.0.0
+      interval: 10m0s
+      sourceRef:
+        kind: HelmRepository
+        name: k0rdent-catalog

--- a/testing_cluster/README.md
+++ b/testing_cluster/README.md
@@ -1,0 +1,28 @@
+# Test charts locally in "kind" cluster
+
+## Setup
+Create local testing cluster
+~~~bash
+kind create cluster --config testing_cluster/kind-cluster.yaml -n testing-cluster
+~~~
+
+Add `k0rdent-catalog` helm charts repo:
+~~~bash
+helm repo add k0rdent-catalog https://k0rdent.github.io/catalog/charts/
+helm search repo k0rdent-catalog # check repo content
+~~~
+
+## Usage
+
+### Install 'nginx-ingress-f5'
+Install `nginx-ingress-f5` using helm chart:
+~~~bash
+helm install nginx-ingress-f5 k0rdent-catalog/nginx-ingress-f5 --namespace nginx-ingress-f5 --create-namespace --set nginx-ingress.controller.hostPort.enable=true
+~~~
+
+### Install 'dapr'
+Install `dapr` using helm chart:
+~~~bash
+helm install dapr k0rdent-catalog/dapr --namespace dapr-system --create-namespace
+kubectl apply -f testing_cluster/ingress-dapr.yaml
+~~~

--- a/testing_cluster/kind-cluster.yaml
+++ b/testing_cluster/kind-cluster.yaml
@@ -1,0 +1,11 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 443
+        protocol: TCP


### PR DESCRIPTION
Service templates charts stored in `charts` folder are by github action script built and pushed to `oci://ghcr.io/k0rdent/catalog/charts` registry.

The script is written the way it works also in forked repos (e.g. [Josca/k0rdent-catalog](https://github.com/Josca/k0rdent-catalog/).

It also includes `*.md` files and k8s manifests helping to setup service templates in k0rdent instance.