### PR TITLE
Add catalog-core-2.0.0 based on kgst

### DIFF
--- a/charts/catalog-core/catalog-core-2.0.0/Chart.lock
+++ b/charts/catalog-core/catalog-core-2.0.0/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: kgst
+  repository: oci://ghcr.io/k0rdent/catalog/charts
+  version: 0.1.0
+- name: kgst
+  repository: oci://ghcr.io/k0rdent/catalog/charts
+  version: 0.1.0
+digest: sha256:3eed33a66b63491c2bb7be641815adc24867fbc21f7c3acac32852325ab9160b
+generated: "2025-03-25T12:40:01.594467+01:00"

--- a/charts/catalog-core/catalog-core-2.0.0/Chart.yaml
+++ b/charts/catalog-core/catalog-core-2.0.0/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: catalog-core
+description: Pre-installed ServiceTemplates for k0rdent
+type: application
+version: 2.0.0
+dependencies:
+  - name: kgst
+    version: 0.1.0
+    repository: oci://ghcr.io/k0rdent/catalog/charts
+    alias: ingress-nginx
+  - name: kgst
+    version: 0.1.0
+    repository: oci://ghcr.io/k0rdent/catalog/charts
+    alias: cert-manager

--- a/charts/catalog-core/catalog-core-2.0.0/values.yaml
+++ b/charts/catalog-core/catalog-core-2.0.0/values.yaml
@@ -1,0 +1,17 @@
+ingress-nginx:
+  helm:
+    repository:
+      name: ingress-nginx
+      url: https://kubernetes.github.io/ingress-nginx
+    charts:
+      - name: ingress-nginx
+        version: 4.11.5
+
+cert-manager:
+  helm:
+    repository:
+      name: cert-manager
+      url: https://charts.jetstack.io
+    charts:
+      - name: cert-manager
+        version: 1.17.0


### PR DESCRIPTION
This demonstrates the way how we could provide a next generation of catalog-core. It's based on kgst helm chart so it doesn't require extra helm charts for a service and service template.