### PR TITLE
chart to deploy certificate issuer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ ignore
 
 apps/*/*/Chart.lock
 apps/*/mcs.y*ml
+
+.idea

--- a/charts/pki/managed-issuer-0-0-1/Chart.yaml
+++ b/charts/pki/managed-issuer-0-0-1/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: managed-issuer
+description: Helm chart to deploy required resources for managed certificates
+type: application
+version: 0.1.0

--- a/charts/pki/managed-issuer-0-0-1/templates/_helpers.tpl
+++ b/charts/pki/managed-issuer-0-0-1/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{/*
+Validate that only one issuer type is enabled
+*/}}
+{{- define "managed-issuer.validateIssuerConfig" -}}
+{{- if and .Values.issuer.acme.enabled .Values.issuer.existingPKI.enabled -}}
+{{- fail "Configuration error: Both issuer.acme.enabled and issuer.existingPKI.enabled cannot be true simultaneously. Please enable only one issuer type." -}}
+{{- end -}}
+
+{{/* Validate that solvers are provided when ACME is enabled */}}
+{{- if .Values.issuer.acme.enabled -}}
+  {{- if empty .Values.issuer.acme.solvers -}}
+    {{- fail "Configuration error: When issuer.acme.enabled is true, you must provide at least one solver in issuer.acme.solvers." -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/pki/managed-issuer-0-0-1/templates/issuer.yaml
+++ b/charts/pki/managed-issuer-0-0-1/templates/issuer.yaml
@@ -1,0 +1,25 @@
+{{- include "managed-issuer.validateIssuerConfig" . -}}
+apiVersion: cert-manager.io/v1
+kind: {{ if .Values.issuer.namespaced }}Issuer{{ else }}ClusterIssuer{{ end }}
+metadata:
+  name: {{ .Release.Name }}
+  {{- if .Values.issuer.namespaced }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+spec:
+  {{- if .Values.issuer.acme.enabled }}
+  acme:
+    email: {{ .Values.issuer.acme.email }}
+    server: {{ .Values.issuer.acme.server }}
+    privateKeySecretRef:
+      name: {{ .Values.issuer.acme.privateKeySecretName }}
+    solvers:
+    {{- toYaml .Values.issuer.acme.solvers | nindent 6 }}
+  {{- else }}
+  {{- if .Values.issuer.existingPKI.enabled }}
+  ca:
+    secretName: {{ .Values.issuer.existingPKI.keyPairSecretName }}
+  {{- else }}
+  selfSigned: {}
+  {{- end }}
+  {{- end }}

--- a/charts/pki/managed-issuer-0-0-1/values.yaml
+++ b/charts/pki/managed-issuer-0-0-1/values.yaml
@@ -1,0 +1,38 @@
+global: {}
+
+issuer:
+  namespaced: true
+  # If acme.enabled is true, then you can use this section to configure
+  # acme server. Otherwise, self-signed issuer will be used
+  acme:
+    enabled: false
+    server: ""
+    email: ""
+    privateKeySecretName: ""
+    # Solvers is a list of challenge solvers that will be used to solve
+    # ACME challenges for the matching domains.
+    # Solver configurations must be provided in order to obtain certificates
+    # from an ACME server.
+    # For more information, see: https://cert-manager.io/docs/configuration/acme/
+    #
+    # Example:
+    # solvers:
+    # - http01:
+    #     ingress:
+    #       class: nginx
+    # - dns01:
+    #     cloudflare:
+    #       email: user@example.com
+    #       apiKeySecretRef:
+    #         name: cloudflare-api-key
+    #         key: api-key
+    solvers: []
+
+  existingPKI:
+    # If disabled self-signed issuer will be created.
+    # For more information, see: https://cert-manager.io/docs/configuration/selfsigned/
+    enabled: true
+    # keyPairSecretRef stands for Secret containing existing issuer key-pair.
+    # It is expected Secret will contain data.tls.crt and data.tls.key fields.
+    # For more information, see: https://cert-manager.io/docs/configuration/ca/
+    keyPairSecretName: ""


### PR DESCRIPTION
This PR contains Helm chart to deploy the `[Cluster]Issuer` with defined configuration to the managed cluster.