### PR TITLE
Add a timeout when waiting for pods to deploy

### DIFF
--- a/scripts/wait_for_deployment.sh
+++ b/scripts/wait_for_deployment.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-while true; do
+TIMEOUT=10*60  # 10 minutes
+SECONDS=0 # Reset the timer built in to bash
+
+while (( SECONDS < ${TIMEOUT})); do
     pods=$(KUBECONFIG="kcfg_$TEST_MODE" kubectl get pods -n "$NAMESPACE" --no-headers 2>&1)
     echo "$TEST_MODE/$NAMESPACE"
     echo "$pods"  # Print the pod list to stdout


### PR DESCRIPTION
Adds a timeout to scripts/wait_for_deployment.sh so that CI doesn't run forever if it's a bad setup:
https://github.com/k0rdent/catalog/actions/runs/14130260713/job/39588542495

I tested this locally running just the loop with a 10 second timeout:
```
nneisen: code/catalog - (add-deployemnt-timeout) > ./scripts/wait_for_deployment.sh
0
3
6
9
nneisen: code/catalog - (add-deployemnt-timeout) > 
```

The timeout is set to 10 minutes. This could be increased or passed in as a parameter