### PR TITLE
Add mkdocs versioning (mike)

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -8,6 +8,7 @@ on:
       - apps/**/data.yaml
       - mkdocs.yml
       - mkdocs/**
+      - scripts/deploy_web.sh
       - .github/workflows/gh-pages-deploy.yml
   pull_request:
     types: [opened, synchronize, reopened]
@@ -15,6 +16,7 @@ on:
       - apps/**/data.yaml
       - mkdocs/**
       - mkdocs.yml
+      - scripts/deploy_web.sh
       - .github/workflows/gh-pages-deploy.yml
 
 permissions:
@@ -28,6 +30,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Configure Git User
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -39,15 +46,18 @@ jobs:
           pip install -r mkdocs/requirements.txt
 
       - name: Test web pages build
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
         run: |
+          echo "REPO: $GITHUB_CONTEXT"
           mkdocs build
 
       - name: Build and Deploy pages - fork
-        if: github.event_name == 'push' && github.event.repository.fork == true
+        if: github.repository != 'k0rdent/catalog' && github.ref != 'refs/heads/main'
         run: |
-          mkdocs gh-deploy --force
+          SITE_URL=${{ vars.SITE_URL }} ./scripts/deploy_web.sh
 
       - name: Build and Deploy pages - k0rdent/catalog
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.repository == 'k0rdent/catalog' && github.ref == 'refs/heads/main'
         run: |
-          mkdocs gh-deploy --force
+          SITE_URL=${{ vars.SITE_URL }} ./scripts/deploy_web.sh

--- a/apps/aks/data.yaml
+++ b/apps/aks/data.yaml
@@ -14,7 +14,7 @@ verify_code: |
     ~~~bash
     kubectl get clustertemplate -n kcm-system
     # NAME                            VALID
-    # azure-aks-0-1-0                 true 
+    # azure-aks-{{ dash_version }}                 true
     ~~~
 deploy_code: |
     ~~~yaml
@@ -24,7 +24,7 @@ deploy_code: |
       name: my-azure-clusterdeployment1
       namespace: kcm-system
     spec:
-      template: azure-aks-0-1-0  # name of the clustertemplate
+      template: azure-aks-{{ dash_version }}  # name of the clustertemplate
       credential: azure-cluster-identity-cred
       config:
         clusterLabels: {}

--- a/apps/aks/data.yaml
+++ b/apps/aks/data.yaml
@@ -35,4 +35,4 @@ deploy_code: |
         worker:
           vmSize: Standard_A4_v2
     ~~~
-doc_link: https://azure.microsoft.com/en-us/products/kubernetes-service
+doc_link: https://docs.k0rdent.io/{{ version }}/admin/installation/prepare-mgmt-cluster/azure/

--- a/apps/aws/data.yaml
+++ b/apps/aws/data.yaml
@@ -20,7 +20,7 @@ verify_code: |
   ~~~bash
   kubectl get clustertemplate -n kcm-system
   # NAME                            VALID
-  # aws-standalone-cp-0-1-0         true
+  # aws-standalone-cp-{{ dash_version }}         true
   ~~~
 deploy_code: |
   ~~~yaml
@@ -30,7 +30,7 @@ deploy_code: |
     name: my-aws-clusterdeployment1
     namespace: kcm-system
   spec:
-    template: aws-standalone-cp-0-1-0
+    template: aws-standalone-cp-{{ dash_version }}
     credential: aws-cluster-identity-cred
     config:
       clusterLabels: {}

--- a/apps/aws/data.yaml
+++ b/apps/aws/data.yaml
@@ -42,4 +42,4 @@ deploy_code: |
         instanceType: t3.small
         rootVolumeSize: 32
   ~~~
-doc_link: https://aws.amazon.com/contact-us/
+doc_link: https://docs.k0rdent.io/{{ version }}/admin/installation/prepare-mgmt-cluster/aws/

--- a/apps/azure/data.yaml
+++ b/apps/azure/data.yaml
@@ -22,7 +22,7 @@ verify_code: |
     ~~~bash
     kubectl get clustertemplate -n kcm-system
     # NAME                            VALID
-    # azure-hosted-cp-0-1-0           true 
+    # azure-hosted-cp-{{ dash_version }}           true
     ~~~
 deploy_code: |
     ~~~yaml
@@ -32,7 +32,7 @@ deploy_code: |
       name: my-azure-clusterdeployment1
       namespace: kcm-system
     spec:
-      template: azure-standalone-cp-0-1-0 # name of the clustertemplate
+      template: azure-standalone-cp-{{ dash_version }} # name of the clustertemplate
       credential: azure-cluster-identity-cred
       config:
         clusterLabels: {}

--- a/apps/azure/data.yaml
+++ b/apps/azure/data.yaml
@@ -43,4 +43,4 @@ deploy_code: |
         worker:
           vmSize: Standard_A4_v2
     ~~~
-doc_link: https://docs.k0rdent.io/latest/template-azure/
+doc_link: https://docs.k0rdent.io/{{ version }}/admin/installation/prepare-mgmt-cluster/azure/

--- a/apps/cert-manager/data.yaml
+++ b/apps/cert-manager/data.yaml
@@ -9,8 +9,10 @@ description: |
 support_link: https://cert-manager.io/support/
 install_code: |
     ~~~bash
+    {% if version == "v0.1.0" %}
     # k0rdent includes the template for Cert-manager 1.16.2 out of the box
     # It's also possible to install a newer version:
+    {% endif %}
     helm upgrade --install cert-manager oci://ghcr.io/k0rdent/catalog/charts/kgst -n kcm-system \
       --set "helm.repository.url=https://charts.jetstack.io" \
       --set "helm.charts[0].name=cert-manager" \
@@ -20,7 +22,7 @@ verify_code: |
     ~~~bash
     kubectl get servicetemplates -A
     # NAMESPACE    NAME                       VALID
-    # kcm-system   cert-manager-1-16-2        true
+    # kcm-system   cert-manager-1-17-1        true
     ~~~
 deploy_code: |
     ~~~yaml
@@ -30,7 +32,7 @@ deploy_code: |
     ...
       serviceSpec:
         services:
-          - template: cert-manager-1-16-2
+          - template: cert-manager-1-17-1
             name: cert-manager
             namespace: cert-manager
             values: |

--- a/apps/dex/data.yaml
+++ b/apps/dex/data.yaml
@@ -10,7 +10,15 @@ description: |
 support_link: https://dexidp.io/docs/guides/kubernetes/
 install_code: |
     ~~~bash
+    {% if version == "v0.1.0" %}
     # k0rdent includes the template for Dex out of the box
+    {% else %}
+    helm upgrade --install dex oci://ghcr.io/k0rdent/catalog/charts/kgst -n kcm-system \
+        --set "helm.repository.url=oci://ghcr.io/k0rdent/catalog/charts" \
+        --set "helm.repository.type=oci" \
+        --set "helm.charts[0].name=dex" \
+        --set "helm.charts[0].version=0.19.1"
+    {% endif %}
     ~~~
 verify_code: |
     ~~~bash

--- a/apps/eks/data.yaml
+++ b/apps/eks/data.yaml
@@ -14,7 +14,7 @@ verify_code: |
   ~~~bash
   kubectl get clustertemplate -n kcm-system
   # NAME                            VALID
-  # aws-eks-0-1-0                   true
+  # aws-eks-{{ dash_version }}                   true
   ~~~
 deploy_code: |
   ~~~yaml
@@ -24,7 +24,7 @@ deploy_code: |
     name: my-aws-clusterdeployment1
     namespace: kcm-system
   spec:
-    template: aws-eks-cp-0-1-0
+    template: aws-eks-cp-{{ dash_version }}
     credential: aws-cluster-identity-cred
     config:
       clusterLabels: {}

--- a/apps/eks/data.yaml
+++ b/apps/eks/data.yaml
@@ -36,4 +36,4 @@ deploy_code: |
         instanceType: t3.small
         rootVolumeSize: 32
   ~~~
-doc_link: https://aws.amazon.com/eks/
+doc_link: https://docs.k0rdent.io/{{ version }}/admin/installation/prepare-mgmt-cluster/aws/

--- a/apps/external-secrets/data.yaml
+++ b/apps/external-secrets/data.yaml
@@ -11,7 +11,14 @@ description: |
 support_link: https://external-secrets.io/latest/introduction/stability-support/
 install_code: |
     ~~~bash
+    {% if version == "v0.1.0" %}
     # k0rdent includes the template for External-secrets out of the box
+    {% else %}
+    helm upgrade --install external-secrets oci://ghcr.io/k0rdent/catalog/charts/kgst -n kcm-system \
+        --set "helm.repository.url=https://charts.external-secrets.io" \
+        --set "helm.charts[0].name=external-secrets" \
+        --set "helm.charts[0].version=0.11.0"
+    {% endif %}
     ~~~
 verify_code: |
     ~~~bash

--- a/apps/gcp/data.yaml
+++ b/apps/gcp/data.yaml
@@ -47,3 +47,4 @@ deploy_code: |
         publicIP: true
   ~~~
 doc_link: https://cloud.google.com/compute/docs
+versions: [v0.2.0]

--- a/apps/gitlab/aws-cld.yaml
+++ b/apps/gitlab/aws-cld.yaml
@@ -3,7 +3,7 @@ kind: ClusterDeployment
 metadata:
   name: aws-example-USER
 spec:
-  template: aws-standalone-cp-0-1-0
+  template: aws-standalone-cp-{{ dash_version }}
   credential: aws-credential
   config:
     clusterLabels:

--- a/apps/gitlab/azure-cld.yaml
+++ b/apps/gitlab/azure-cld.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-example-USER
   namespace: kcm-system
 spec:
-  template: azure-standalone-cp-0-1-0
+  template: azure-standalone-cp-{{ dash_version }}
   credential: azure-credential
   config:
     clusterLabels:

--- a/apps/gitlab/data.yaml
+++ b/apps/gitlab/data.yaml
@@ -31,7 +31,7 @@ deploy_code: |
     metadata:
       name: aws-example
     spec:
-      template: aws-standalone-cp-0-1-0
+      template: aws-standalone-cp-{{ dash_version }}
       credential: aws-credential
       config:
         worker:
@@ -48,7 +48,7 @@ deploy_code: |
     metadata:
       name: azure-example
     spec:
-      template: azure-standalone-cp-0-1-0
+      template: azure-standalone-cp-{{ dash_version }}
       credential: azure-credential
       config:
         worker:

--- a/apps/gke/data.yaml
+++ b/apps/gke/data.yaml
@@ -45,3 +45,4 @@ deploy_code: |
         name: default # Select your desired network name (select new network name to create or find it via `gcloud compute networks list --format="value(name)"`)
   ~~~
 doc_link: https://cloud.google.com/kubernetes-engine/docs
+versions: [v0.2.0]

--- a/apps/ingress-nginx/data.yaml
+++ b/apps/ingress-nginx/data.yaml
@@ -15,9 +15,11 @@ description: |
 support_link: https://www.f5.com/products/nginx/nginx-ingress-controller
 install_code: |
     ~~~bash
+    {% if version == "v0.1.0" %}
     # k0rdent includes the template for Ingress-nginx 4.11.3 out of the box
     # This version is out-of-date and vulnerable (CVE-2025-1974).
     # It's also possible to install a newer version:
+    {% endif %}
     helm upgrade --install ingress-nginx oci://ghcr.io/k0rdent/catalog/charts/kgst -n kcm-system \
       --set "helm.repository.url=https://kubernetes.github.io/ingress-nginx" \
       --set "helm.charts[0].name=ingress-nginx" \

--- a/apps/kyverno/data.yaml
+++ b/apps/kyverno/data.yaml
@@ -17,7 +17,14 @@ description: |
 support_link: https://nirmata.com/nirmata-enterprise-for-kyverno/
 install_code: |
     ~~~bash
+    {% if version == "v0.1.0" %}
     # k0rdent includes the template for Kyverno out of the box
+    {% else %}
+    helm upgrade --install kyverno oci://ghcr.io/k0rdent/catalog/charts/kgst -n kcm-system \
+        --set "helm.repository.url=https://kyverno.github.io/kyverno/" \
+        --set "helm.charts[0].name=kyverno" \
+        --set "helm.charts[0].version=3.2.6"
+    {% endif %}
     ~~~
 verify_code: |
     ~~~bash

--- a/apps/nvidia/aws-cld.yaml
+++ b/apps/nvidia/aws-cld.yaml
@@ -3,7 +3,7 @@ kind: ClusterDeployment
 metadata:
   name: aws-example-USER
 spec:
-  template: aws-standalone-cp-0-1-0
+  template: aws-standalone-cp-{{ dash_version }}
   credential: aws-credential
   config:
     clusterLabels:

--- a/apps/nvidia/azure-cld.yaml
+++ b/apps/nvidia/azure-cld.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-example-USER
   namespace: kcm-system
 spec:
-  template: azure-standalone-cp-0-1-0
+  template: azure-standalone-cp-{{ dash_version }}
   credential: azure-credential
   config:
     clusterLabels:

--- a/apps/nvidia/data.yaml
+++ b/apps/nvidia/data.yaml
@@ -31,7 +31,7 @@ deploy_code: |
     metadata:
       name: aws-example-cluster
     spec:
-      template: aws-standalone-cp-0-1-0
+      template: aws-standalone-cp-{{ dash_version }}
       credential: aws-credential
       config:
         clusterLabels:

--- a/apps/open-webui/aws-cld.yaml
+++ b/apps/open-webui/aws-cld.yaml
@@ -3,7 +3,7 @@ kind: ClusterDeployment
 metadata:
   name: aws-example-USER
 spec:
-  template: aws-standalone-cp-0-1-0
+  template: aws-standalone-cp-{{ dash_version }}
   credential: aws-credential
   config:
     clusterLabels:

--- a/apps/open-webui/data.yaml
+++ b/apps/open-webui/data.yaml
@@ -33,7 +33,7 @@ deploy_code: |
     metadata:
       name: aws-example
     spec:
-      template: aws-standalone-cp-0-1-0
+      template: aws-standalone-cp-{{ dash_version }}
       credential: aws-credential
       config:
         ...

--- a/apps/openstack/data.yaml
+++ b/apps/openstack/data.yaml
@@ -51,4 +51,4 @@ deploy_code: |
           cloudName: openstack
           region: RegionOne
     ~~~
-doc_link: https://docs.k0rdent.io/latest/template-openstack/
+doc_link: https://docs.k0rdent.io/{{ version }}/admin/installation/prepare-mgmt-cluster/openstack/

--- a/apps/openstack/data.yaml
+++ b/apps/openstack/data.yaml
@@ -15,7 +15,7 @@ verify_code: |
     ~~~yaml
     kubectl get clustertemplate -n kcm-system
     # NAME                            VALID
-    # openstack-standalone-cp-0-1-0   true
+    # openstack-standalone-cp-{{ dash_version }}   true
     ~~~
 deploy_code: |
     ~~~yaml
@@ -25,7 +25,7 @@ deploy_code: |
       name: my-openstack-cluster-deployment
       namespace: kcm-system
     spec:
-      template: openstack-standalone-cp-0-1-0
+      template: openstack-standalone-cp-{{ dash_version }}
       credential: openstack-cluster-identity-cred
       config:
         clusterLabels: {}

--- a/apps/velero/data.yaml
+++ b/apps/velero/data.yaml
@@ -8,7 +8,14 @@ description: |
     and migrate Kubernetes cluster resources and persistent volumes.
 install_code: |
     ~~~bash
+    {% if version == "v0.1.0" %}
     # k0rdent includes the template for Velero out of the box
+    {% else %}
+    helm upgrade --install velero oci://ghcr.io/k0rdent/catalog/charts/kgst -n kcm-system \
+        --set "helm.repository.url=https://vmware-tanzu.github.io/helm-charts/" \
+        --set "helm.charts[0].name=velero" \
+        --set "helm.charts[0].version=8.1.0"
+    {% endif %}
     ~~~
 verify_code: |
     ~~~bash

--- a/apps/vsphere/data.yaml
+++ b/apps/vsphere/data.yaml
@@ -15,7 +15,7 @@ verify_code: |
     ~~~yaml
     kubectl get clustertemplate -n kcm-system
     # NAME                            VALID
-    # vsphere-hosted-cp-0-1-0         true
+    # vsphere-hosted-cp-{{ dash_version }}         true
     ~~~
 deploy_code: |
     ~~~yaml
@@ -25,7 +25,7 @@ deploy_code: |
       name: my-vsphere-clusterdeployment1
       namespace: kcm-system
     spec:
-      template: vsphere-hosted-cp-0-1-0
+      template: vsphere-hosted-cp-{{ dash_version }}
       credential: vsphere-credential
       config:
         clusterLabels: {}

--- a/apps/vsphere/data.yaml
+++ b/apps/vsphere/data.yaml
@@ -51,4 +51,4 @@ deploy_code: |
             annotations:
               kube-vip.io/loadbalancerIPs: "<VSPHERE_LOADBALANCER_IP>"
     ~~~
-doc_link: https://docs.k0rdent.io/latest/template-vsphere/
+doc_link: https://docs.k0rdent.io/{{ version }}/admin/installation/prepare-mgmt-cluster/vmware/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,9 +50,14 @@ theme:
 extra_css:
   - extra.css
 
+extra:
+  version:
+    provider: mike
+
 plugins:
   - search
   - tags
+  - mike
   - gen-files:
       scripts:
         - mkdocs/gen_app_pages.py

--- a/mkdocs/app.tpl.md
+++ b/mkdocs/app.tpl.md
@@ -29,7 +29,7 @@ type: "{{ type }}"
 
     #### Prerequisites
 
-    Deploy k0rdent {{ version }}: [QuickStart](https://docs.k0rdent.io/{{ version }}/guide-to-quickstarts/#guide-to-quickstarts){ target="_blank" }
+    Deploy k0rdent {{ version }}: [QuickStart](https://docs.k0rdent.io/{{ version }}/admin/installation/install-k0rdent/){ target="_blank" }
 
     {% if use_ingress %}
     Deploy [Ingress-nginx](../../../apps/ingress-nginx/ingress-nginx/#__tabbed_1_2){ target="_blank" } to expose application web UI

--- a/mkdocs/app.tpl.md
+++ b/mkdocs/app.tpl.md
@@ -29,7 +29,7 @@ type: "{{ type }}"
 
     #### Prerequisites
 
-    Deploy k0rdent: [QuickStart](https://docs.k0rdent.io/v0.1.0/guide-to-quickstarts/#guide-to-quickstarts){ target="_blank" }
+    Deploy k0rdent {{ version }}: [QuickStart](https://docs.k0rdent.io/{{ version }}/guide-to-quickstarts/#guide-to-quickstarts){ target="_blank" }
 
     {% if use_ingress %}
     Deploy [Ingress-nginx](../../../apps/ingress-nginx/ingress-nginx/#__tabbed_1_2){ target="_blank" } to expose application web UI

--- a/mkdocs/extra.css
+++ b/mkdocs/extra.css
@@ -24,8 +24,15 @@ body{
   font-size: 24px;
 }
 
+.md-version{
+	display: flex;
+}
 .md-version__list {
   overflow: auto;
+  top: 32px;
+}
+.md-version__link:hover {
+  background-color: var(--md-default-fg-color--lightest);
 }
 
 ul.video-list {
@@ -331,7 +338,7 @@ body:has(.homepage) .back-to-catalog{
     grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
   }
   .md-header__button.md-logo img{
-    max-width: 250px;
+    max-width: 170px;
   }
   .md-header .md-header__title .md-ellipsis {
     letter-spacing: 1.4;

--- a/scripts/config/adopted-cld.yaml
+++ b/scripts/config/adopted-cld.yaml
@@ -4,7 +4,7 @@ metadata:
   name: adopted
   namespace: kcm-system
 spec:
-  template: adopted-cluster-0-1-0
+  template: adopted-cluster-{{ dash_version }}
   credential: adopted-credential
   config:
     clusterLabels:

--- a/scripts/config/aws-cld.yaml
+++ b/scripts/config/aws-cld.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-example-USER
   namespace: kcm-system
 spec:
-  template: aws-standalone-cp-0-1-0
+  template: aws-standalone-cp-{{ dash_version }}
   credential: aws-credential
   config:
     clusterLabels:

--- a/scripts/config/azure-cld.yaml
+++ b/scripts/config/azure-cld.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-example-USER
   namespace: kcm-system
 spec:
-  template: azure-standalone-cp-0-1-0
+  template: azure-standalone-cp-{{ dash_version }}
   credential: azure-credential
   config:
     clusterLabels:

--- a/scripts/deploy_web.sh
+++ b/scripts/deploy_web.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eo pipefail
+
+if [[ -n "$SITE_URL" ]]; then
+    echo "site url found: $SITE_URL"
+    echo "site_url: $SITE_URL" >> mkdocs.yml
+    KIND_CLUSTER="k0rdent"
+else
+    echo "SITE_URL not found"
+fi
+rm -rf mkdocs/apps
+VERSION="v0.1.0" mkdocs build # generate md files
+VERSION="v0.1.0" mike deploy v0.1.0
+rm -rf mkdocs/apps
+VERSION="v0.2.0" mkdocs build # generate md files
+VERSION="v0.2.0" mike deploy v0.2.0 latest stable --update-aliases
+mike set-default v0.2.0
+git push origin gh-pages -f


### PR DESCRIPTION
- k0rdent/catalog#267

- Testing instance of versioned Catalog for review: https://josca.github.io/k0rdent-catalog-3

- [x] Add versions drop down switch (v0.1.0, v0.2.0) [link](https://josca.github.io/k0rdent-catalog-3/v0.2.0/)
- [x] Update k0rdent installation [link](https://josca.github.io/k0rdent-catalog-3/v0.2.0/apps/dapr/dapr/#prerequisites)
- [x] Update Cluster template version [link](https://josca.github.io/k0rdent-catalog-3/v0.2.0/apps/aws/aws/#verify-cluster-template)
- [x] Update pre-installed apps installation info [link](https://josca.github.io/k0rdent-catalog-3/v0.2.0/apps/velero/velero/#install-template-to-k0rdent)
- [x] Update infra cluster templates doc links [link](https://josca.github.io/k0rdent-catalog-3/v0.1.0/apps/openstack/openstack/#create-a-cluster-on-openstack)
- [x] Ensure GCP infras not visible for v0.1.0 [link](https://josca.github.io/k0rdent-catalog-3/v0.1.0/#infra)