### PR TITLE
feat(kind): allow configurable master and worker node counts via workflow inputs

### DIFF
--- a/.github/workflows/helm-app-deploy.yml
+++ b/.github/workflows/helm-app-deploy.yml
@@ -1,6 +1,16 @@
 name: Test changed apps
 
 on:
+  workflow_dispatch:
+    inputs:
+      masters:
+        description: 'Number of master nodes'
+        required: false
+        default: '1'
+      workers:
+        description: 'Number of worker nodes'
+        required: false
+        default: '1'
   push:
     branches:
       - '*'
@@ -83,6 +93,12 @@ jobs:
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
           kind version
+
+      - name: Create Kind Cluster config
+        run: |
+          export MASTERS=${{ github.event.inputs.masters || '1' }}
+          export WORKERS=${{ github.event.inputs.workers || '1' }}
+          ./scripts/create_kind_config.sh
 
       - name: Create Kind Cluster
         run: |

--- a/scripts/create_kind_config.sh
+++ b/scripts/create_kind_config.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+
+MASTERS=${MASTERS:-1}
+WORKERS=${WORKERS:-1}
+
+echo "Creating KIND config with $MASTERS masters and $WORKERS workers"
+
+cat <<EOF > kind-config.yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+EOF
+
+for i in $(seq 1 $MASTERS); do
+  echo "- role: control-plane" >> kind-config.yaml
+done
+
+for i in $(seq 1 $WORKERS); do
+  echo "- role: worker" >> kind-config.yaml
+done


### PR DESCRIPTION
Added the capability of manual triggering with optional inputs to specify the number of master and worker nodes.
