### PR TITLE
MSR: fix installation instructions

### DIFF
--- a/apps/msr/data.yaml
+++ b/apps/msr/data.yaml
@@ -14,7 +14,8 @@ description: |
 install_code: |
     ~~~bash
     helm upgrade --install harbor oci://ghcr.io/k0rdent/catalog/charts/kgst -n kcm-system \
-        --set "helm.repository.url=https://registry.mirantis.com/charts/harbor/helm" \
+        --set "helm.repository.url=oci://registry.mirantis.com/harbor/helm" \
+        --set "helm.repository.type=oci"
         --set "helm.charts[0].name=harbor" \
         --set "helm.charts[0].version=4.0.1"
     ~~~


### PR DESCRIPTION
While testing MSR installation using current docs on catalog.k0rdent.io  got error in helmrepositories object:
```shell
$ kubectl get helmrepositories.source.toolkit.fluxcd.io -n kcm-system harbor
```
```console
NAME     URL                                                AGE   READY   STATUS
harbor   https://registry.mirantis.com/charts/harbor/helm   66s   False   failed to load Helm repository from index YAML: failed to load index: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type repo.IndexFile
```
 
 After changes in PR MSR4 was available to deploy without issues