### PR TITLE
added support_type to the filters sidebar

### DIFF
--- a/mkdocs/app.tpl.md
+++ b/mkdocs/app.tpl.md
@@ -11,6 +11,7 @@ title: {{ title }}
 description: {{ summary }}
 logo: "{{ logo }}"
 type: "{{ type }}"
+support_type: "{{ support_type }}"
 ---
 ![logo]({{ logo_big }}){ align="right", width="100" }
 # {{ title }}

--- a/mkdocs/gen_metadata.py
+++ b/mkdocs/gen_metadata.py
@@ -31,6 +31,7 @@ for file_path in paths:
         "type": metadata.get("type", " "),
         "logo": metadata.get("logo", " "),
         "tags": metadata.get("tags", []),
+        "support_type": metadata.get("support_type", "Community"),
         "description": metadata.get("description", "No Description"),
         "appDir": file_path.replace("\\", "/").split("/")[-2], # ensure it works for windows (backslashes)
     })

--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -39,6 +39,18 @@ template: home.html
               </div>
               <br>
             </div>
+            <p class="categories-title" @click="toggleExpanded($event)">Support: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M233.4 406.6c12.5 12.5 32.8 12.5 45.3 0l192-192c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L256 338.7 86.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l192 192z"/></svg></p>
+            <div id="filterTagsApps" class="expandable-list">
+              <div v-for="tag in [...supportTypeSet].sort((a, b) => a.localeCompare(b))">
+                <input type="checkbox" 
+                  :id="tag.replace(/[ /]/g, '-').toLowerCase()" 
+                  :name="tag.replace(/[ /]/g, '-').toLowerCase()" 
+                  :value="tag.replace(/[ /]/g, '-').toLowerCase()" 
+                  v-model="checkboxesAppsSupport">
+                <label :for="tag.replace(/[ /]/g, '-').toLowerCase()">{{ tag }}</label>
+              </div>
+              <br>
+            </div>
           </div>
           <div class="tab_apps-main-content">
             <div id="cards-apps" class="grid">
@@ -104,7 +116,9 @@ template: home.html
       const data_apps = ref([])
       const data_apps_filtered = ref([])
       const checkboxesApps = ref([])
+      const checkboxesAppsSupport = ref([])
       const tagsSet = new Set()
+      const supportTypeSet = new Set()
 
       //methods
       const readData = ()=>{
@@ -116,9 +130,15 @@ template: home.html
             data_apps.value = res.filter(item=>item.type !== 'infra')
 
             data_apps.value.forEach(item=>{
+              if(item.support_type !==''){
+                supportTypeSet.add(item.support_type)
+              } else {
+                // add support_type "Community" to all items that doesn't have "Enterprise"-tag
+                item.support_type = "Community"
+                supportTypeSet.add(item.support_type)
+              }
               item.tags.forEach(tag => tagsSet.add(tag));
             })
-
             data_apps_filtered.value = data_apps.value
             sortingByTitle(data_apps_filtered.value, 'asc')
             sortingByTitle(data_infra.value, 'asc')
@@ -213,14 +233,49 @@ template: home.html
       })
 
       watch(checkboxesApps, (newVal, oldVal) => {
+        let item_tags_lowercased = []
         if(newVal.length>0){
           data_apps_filtered.value = data_apps.value.filter(item=>{
-            return item.tags.some( elem => checkboxesApps.value.includes(elem.replace(/[ /]/g, "-").toLowerCase()) )
+            item_tags_lowercased = item.tags.map(item => item.replace(/[ /]/g, "-").toLowerCase())
+            if(checkboxesAppsSupport.value.length>0){
+              return checkboxesApps.value.every( elem => item_tags_lowercased.includes(elem.replace(/[ /]/g, "-").toLowerCase()) ) && checkboxesAppsSupport.value.every(elem => elem === item.support_type.replace(/[ /]/g, "-").toLowerCase()) 
+            } else {
+              return checkboxesApps.value.every( elem => item_tags_lowercased.includes(elem.replace(/[ /]/g, "-").toLowerCase()) )
+            } 
           })
         } else {
-          data_apps_filtered.value = data_apps.value
+          if(checkboxesAppsSupport.value.length>0){
+            data_apps_filtered.value = data_apps.value.filter(item=>{
+              return checkboxesAppsSupport.value.every(elem => elem === item.support_type.replace(/[ /]/g, "-").toLowerCase())
+            })
+          } else {
+            data_apps_filtered.value = data_apps.value
+          }
         }
         updateURL()
+      }, { deep: true })
+
+      watch(checkboxesAppsSupport, (newVal, oldVal) => {
+        let item_tags_lowercased = []
+        if(newVal.length>0){
+          data_apps_filtered.value = data_apps.value.filter(item=>{
+            item_tags_lowercased = item.tags.map(item => item.replace(/[ /]/g, "-").toLowerCase())
+            if(checkboxesApps.value.length>0){
+              return checkboxesAppsSupport.value.every(elem => elem === item.support_type.replace(/[ /]/g, "-").toLowerCase()) && checkboxesApps.value.every( elem => item_tags_lowercased.includes(elem.replace(/[ /]/g, "-").toLowerCase()) )
+            } else {
+              return checkboxesAppsSupport.value.every(elem => elem === item.support_type.replace(/[ /]/g, "-").toLowerCase())
+            }
+          })
+        } else {
+          if(checkboxesApps.value.length>0){
+            data_apps_filtered.value = data_apps.value.filter(item=>{
+              item_tags_lowercased = item.tags.map(item => item.replace(/[ /]/g, "-").toLowerCase())
+              return checkboxesApps.value.every( elem => item_tags_lowercased.includes(elem.replace(/[ /]/g, "-").toLowerCase()) )
+            })
+          } else {
+            data_apps_filtered.value = data_apps.value
+          }
+        }
       }, { deep: true })
 
       return {
@@ -230,8 +285,10 @@ template: home.html
         data_apps_filtered,
         updateRelLink,
         tagsSet,
+        supportTypeSet,
         ordering,
         checkboxesApps,
+        checkboxesAppsSupport,
         toggleExpanded,
         switchedTabs
       }


### PR DESCRIPTION
- Support-type added to the categories
- Categories filtering reworked to choose items by "AND" instead of "OR" when more than one category selected
- "Community" is set as a default support_type for the items that aren't "Enterprise"