### PR TITLE
URL readability improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ scripts/set_envs.sh
 *ign*
 kcfg*
 mkdocs/apps/*
+mkdocs/infra/*
 
 ignore
 

--- a/apps/open-webui/data.yaml
+++ b/apps/open-webui/data.yaml
@@ -70,7 +70,7 @@ deploy_code: |
     ~~~
     
     ##### Configuration with GPU
-    This setup requires corresponding cluster setup, see [NVIDIA GPU Operator](../../../apps/nvidia/nvidia/#__tabbed_1_2){ target="_blank" }
+    This setup requires corresponding cluster setup, see [NVIDIA GPU Operator](../../../apps/nvidia/nvidia/#install){ target="_blank" }
 
     ~~~yaml
     apiVersion: k0rdent.mirantis.com/v1alpha1

--- a/apps/open-webui/data.yaml
+++ b/apps/open-webui/data.yaml
@@ -70,7 +70,7 @@ deploy_code: |
     ~~~
     
     ##### Configuration with GPU
-    This setup requires corresponding cluster setup, see [NVIDIA GPU Operator](../../../apps/nvidia/nvidia/#install){ target="_blank" }
+    This setup requires corresponding cluster setup, see [NVIDIA GPU Operator](../../../apps/nvidia/#install){ target="_blank" }
 
     ~~~yaml
     apiVersion: k0rdent.mirantis.com/v1alpha1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,9 @@ markdown_extensions:
       pygments_lang_class: true
   - pymdownx.tabbed:
       alternate_style: true
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences

--- a/mkdocs/app.tpl.md
+++ b/mkdocs/app.tpl.md
@@ -37,7 +37,7 @@ support_type: "{{ support_type }}"
     {%- endif %}
 
     {% if use_ingress %}
-    Deploy [Ingress-nginx](../../../apps/ingress-nginx/ingress-nginx/#install){ target="_blank" } to expose application web UI
+    Deploy [Ingress-nginx](../../../apps/ingress-nginx/#install){ target="_blank" } to expose application web UI
     {%- endif %}
 
     #### Install template to k0rdent

--- a/mkdocs/app.tpl.md
+++ b/mkdocs/app.tpl.md
@@ -37,7 +37,7 @@ support_type: "{{ support_type }}"
     {%- endif %}
 
     {% if use_ingress %}
-    Deploy [Ingress-nginx](../../../apps/ingress-nginx/ingress-nginx/#__tabbed_1_2){ target="_blank" } to expose application web UI
+    Deploy [Ingress-nginx](../../../apps/ingress-nginx/ingress-nginx/#install){ target="_blank" } to expose application web UI
     {%- endif %}
 
     #### Install template to k0rdent

--- a/mkdocs/gen_app_pages.py
+++ b/mkdocs/gen_app_pages.py
@@ -142,6 +142,8 @@ def generate_apps():
             print(f"Skip {app} in version {VERSION}")
             continue
         dst_app_path = os.path.join(dst_dir, app_path)
+        if metadata.get("type", "app") == "infra":
+            dst_app_path = dst_app_path.replace("/apps/", "/infra/")
         if not os.path.exists(dst_app_path):
             os.makedirs(dst_app_path)
         md_file = os.path.join(dst_app_path, 'index.md')

--- a/mkdocs/gen_app_pages.py
+++ b/mkdocs/gen_app_pages.py
@@ -144,7 +144,7 @@ def generate_apps():
         dst_app_path = os.path.join(dst_dir, app_path)
         if not os.path.exists(dst_app_path):
             os.makedirs(dst_app_path)
-        md_file = os.path.join(dst_app_path, app + '.md')
+        md_file = os.path.join(dst_app_path, 'index.md')
         try_copy_assets(app, apps_dir, dst_dir)
         # Render the template with metadata
         rendered_md = template.render(**metadata)

--- a/mkdocs/gen_metadata.py
+++ b/mkdocs/gen_metadata.py
@@ -4,7 +4,7 @@ import mkdocs_gen_files
 import yaml
 import glob
 
-paths = glob.glob("./mkdocs/apps/*/*.md")
+paths = glob.glob("./mkdocs/apps/*/*.md") + glob.glob("./mkdocs/infra/*/*.md")
 metadata_list = []
 
 for file_path in paths:

--- a/mkdocs/gen_metadata.py
+++ b/mkdocs/gen_metadata.py
@@ -26,7 +26,7 @@ for file_path in paths:
         metadata = yaml.safe_load("\n".join(yaml_content)) or {}
 
     metadata_list.append({
-        "link": file_path.replace("./mkdocs", ".").removesuffix(".md") + "/",
+        "link": os.path.dirname(file_path).replace("./mkdocs", ".") + "/",
         "title": metadata.get("title", "No Title"),
         "type": metadata.get("type", " "),
         "logo": metadata.get("logo", " "),


### PR DESCRIPTION
- Simplify app page url: `catalog.k0rdent/apps/dapr/dapr/` -> `catalog.k0rdent/apps/dapr/dapr/`
- Use `/infra/` path for infra items :`catalog.k0rdent/apps/aws/` -> `catalog.k0rdent/infra/aws/`
- Use natural tabs url ids:  -> `#__tabbed_1_2` -> `#install`

Demo: https://josca.github.io/k0rdent-catalog-2/v0.2.0/