### PR TITLE
fix: typos in dex manifests

### DIFF
--- a/apps/dex/data.yaml
+++ b/apps/dex/data.yaml
@@ -37,14 +37,13 @@ deploy_code: |
             namespace: dex
             values: |
               dex:
-                dex:
-                  config:
-                    issuer: https://dex.tunnelto.dev/dex
-                    storage:
-                      type: memory
-                    connectors:
-                      - type: mockCallback
-                        id: mock
-                        name: Example
+                config:
+                  issuer: https://dex.tunnelto.dev/dex
+                  storage:
+                    type: memory
+                  connectors:
+                    - type: mockCallback
+                      id: mock
+                      name: Example
     ~~~
 doc_link: https://dexidp.io/docs/


### PR DESCRIPTION
This commit fixes an issue with the dex manifest.

Deploying with the original YAML results in a pod with `CrashLoopBackOff`.

Updating it to use the YAML in this PR results in a successful pod `Ready` status.