### PR TITLE
Fix cert-manager Example

### DIFF
--- a/apps/cert-manager/data.yaml
+++ b/apps/cert-manager/data.yaml
@@ -23,9 +23,8 @@ deploy_code: |
             name: cert-manager
             namespace: cert-manager
             values: |
-              cert-manager:
-                crds:
-                  enabled: false  # default
+              crds:
+                enabled: false  # default
     ~~~
 doc_link: https://cert-manager.io/docs/installation/helm/
 


### PR DESCRIPTION
This commit fix the value field for cert-manager example for the correct hierarchy.