### PR TITLE
fix: `kgst` should allow `additionalProperties` to support `global` values

### DIFF
--- a/apps/k0rdent-utils/charts/kgst-1.0.0/values.schema.json
+++ b/apps/k0rdent-utils/charts/kgst-1.0.0/values.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "repo",
     "chart"


### PR DESCRIPTION
* `kof-mothership` uses special `global` values [here](https://github.com/k0rdent/kof/blob/dac8377fb5866d40de66b2583d7c1d302ee19d09/charts/kof-mothership/values.yaml#L1).
* They are propagated by Helm to all sub-charts ([docs](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/#global-chart-values)) including `kgst`.
* Starting from `kgst-1.0.0` there is `values.schema.json` which has `"additionalProperties": false`.
* This leads to the error on attempt to upgrade `kgst` to version 1.0.0:
```
[ERROR] templates/: values don't meet the specifications of the schema(s) in the following chart(s):
cert-manager-service-template:
- (root): Additional property global is not allowed
ingress-nginx-service-template:
- (root): Additional property global is not allowed
```
* This PR allows `additionalProperties` to fix this issue.
