### PR TITLE
Add working example values.yaml for Velero on AWS

### DIFF
--- a/apps/velero/example/values.yaml
+++ b/apps/velero/example/values.yaml
@@ -1,0 +1,34 @@
+  velero:
+    backupsEnabled: true
+    snapshotsEnabled: true
+    deployNodeAgent: true
+    nodeAgent:
+      podVolumePath: /var/lib/k0s/kubelet/pods
+    initContainers:
+      - name: velero-plugin-for-aws
+        image: velero/velero-plugin-for-aws:latest
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+          - mountPath: /target
+            name: plugins
+    configuration:
+      uploaderType: kopia
+      backupStorageLocation:
+        - name: velero-backup-storage-location
+          provider: aws
+          bucket: velero-backups-xx
+          default: true
+          config:
+            region: us-east-2
+      volumeSnapshotLocation:
+        - name: velero-volume-storage-location
+          provider: aws
+          config:
+            region: us-east-2
+    credentials:
+      useSecret: true
+      secretContents:
+        cloud: |
+          [default]
+          aws_access_key_id = xx
+          aws_secret_access_key = xx


### PR DESCRIPTION
Adds a fully working example/values.yaml for Velero configured with AWS as the backup and snapshot provider.

Enables:
- Full cluster backups (backupsEnabled: true)
- Volume snapshots (snapshotsEnabled: true)
- Deployment of nodeAgent with correct podVolumePath for k0s.
- Integrates the AWS plugin using initContainers with velero/velero-plugin-for-aws:latest.

Configures:
- uploaderType as kopia for optimized backup performance.
- backupStorageLocation with bucket, region, and provider as aws.
- volumeSnapshotLocation targeting the same AWS region.
- Uses credentials.secretContents.cloud to supply AWS access credentials directly.