### PR TITLE
ceph: update docs service values for 1.0.12 version

### DIFF
--- a/apps/ceph/data.yaml
+++ b/apps/ceph/data.yaml
@@ -43,6 +43,14 @@ deploy_code: |
         - template: ceph-controller-1-0-12
           name: ceph-controller
           namespace: ceph-lcm-mirantis
+          values: |
+            ceph-operator:
+              rookExtraConfig:
+                csiKubeletPath: /var/lib/k0s/kubelet
+              controllers:
+                cephMaintenance:
+                  enabled: false
+              installNamespaces: false
     ~~~
 doc_link: https://www.mirantis.com/software/ceph/
 show_install_tab: true

--- a/apps/ceph/example/values.yaml
+++ b/apps/ceph/example/values.yaml
@@ -1,0 +1,8 @@
+ceph-controller:
+  ceph-operator:
+    rookExtraConfig:
+      csiKubeletPath: /var/lib/k0s/kubelet
+    controllers:
+      cephMaintenance:
+        enabled: false
+    installNamespaces: false


### PR DESCRIPTION
Add missed values required for the successful ceph service deployment.