### PR TITLE
Add DEBUG mode to app testing

### DIFF
--- a/.github/workflows/helm-app-deploy.yml
+++ b/.github/workflows/helm-app-deploy.yml
@@ -87,6 +87,8 @@ jobs:
           test_settings=$(python3 ./scripts/utils.py print-test-vars "$app")
           echo "$test_settings"
           echo "$test_settings" >> $GITHUB_ENV
+          echo "DEBUG=${{ runner.debug }}"
+          echo "DEBUG=${{ runner.debug }}" >> $GITHUB_ENV
 
       - name: Check app charts changed
         run: |

--- a/scripts/wait_for_deployment.sh
+++ b/scripts/wait_for_deployment.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
+debug="${DEBUG:-}"
 TIMEOUT=$((25 * 60))
 SECONDS=0
 
@@ -45,6 +46,10 @@ while (( SECONDS < TIMEOUT )); do
                 all_ready=false
             fi
         else
+            if [[ $debug == "1" ]]; then
+                echo "Pod '$name', status: '$status'"
+                KUBECONFIG="kcfg_$TEST_MODE" kubectl describe pod "$name" -n "$NAMESPACE"
+            fi
             all_ready=false
             all_running=false
         fi


### PR DESCRIPTION
- usage: DEBUG=1 ./scripts/deploy_mcs.sh
- also used when restarting GitHub CI jobs with debug mode enabled