### PR TITLE
fix github worflows to use '**' for branch matching

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -3,7 +3,7 @@ name: Deploy MkDocs to GitHub Pages
 on:
   push:
     branches:
-      - '*'
+      - '**'
     paths:
       - apps/**/data.yaml
       - apps/**/hunspell_dict.txt

--- a/.github/workflows/helm-app-deploy.yml
+++ b/.github/workflows/helm-app-deploy.yml
@@ -19,7 +19,7 @@ on:
     - cron: '0 9 * * *'   # 09:00 UTC
   push:
     branches:
-      - '*'
+      - '**'
     paths:
       - apps/**
       - '!apps/*/charts/**'

--- a/.github/workflows/helm-chart-build.yml
+++ b/.github/workflows/helm-chart-build.yml
@@ -3,7 +3,7 @@ name: Build Charts
 on:
   push:
     branches:
-      - '*'
+      - '**'
     paths:
       - apps/*/charts/**
       - .github/workflows/helm-chart-build.yml


### PR DESCRIPTION
## Issue

Github workflows wouldn't run for non-main branches in forked catalog repos which would eventually lead to failure in CI in k0rdent/catalog upon PRs.

## Fix

Reference: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet

```
*: Matches zero or more characters, but does not match the / character. For example, Octo* matches Octocat.
**: Matches zero or more of any character.
```
So, workflows were skipped for branches with '/' for e.g. ramesseii2/k0rdent-catalog::RAMESSES/fix-image.
The alternative would be to drop `branches:` all together in the workflows