### PR TITLE
postgresql: fix failing image check

### DIFF
--- a/apps/postgresql/data.yaml
+++ b/apps/postgresql/data.yaml
@@ -133,3 +133,5 @@ examples: |
     ~~~
 
 doc_link: https://github.com/bitnami/charts/tree/main/bitnami/postgresql
+
+test_check_images_args: "--set image.repository=bitnamilegacy/postgresql=1.31.4"


### PR DESCRIPTION
- use CHECK_IMAGES_ARGS
- use test_check_images_args: "--set image.repository=bitnamilegacy/postgresql=1.31.4"