### PR TITLE
pelagia-ceph: Migrate ceph-controller to upstream version

### DIFF
--- a/apps/ceph/data.yaml
+++ b/apps/ceph/data.yaml
@@ -26,8 +26,8 @@ description: |
 support_link: https://www.mirantis.com/software/ceph/
 support_type: Enterprise
 charts:
-  - name: ceph-controller
-    versions: ['1.0.12']
+  - name: pelagia-ceph
+    versions: ['1.0.0']
 deploy_code: |
     ~~~yaml
     apiVersion: k0rdent.mirantis.com/v1beta1
@@ -40,17 +40,13 @@ deploy_code: |
           group: demo
       serviceSpec:
         services:
-        - template: ceph-controller-1-0-12
-          name: ceph-controller
+        - template: pelagia-1-0-0
+          name: pelagia-ceph
           namespace: ceph-lcm-mirantis
           values: |
-            ceph-operator:
-              rookExtraConfig:
+            pelagia-ceph:
+              rookConfig:
                 csiKubeletPath: /var/lib/k0s/kubelet
-              controllers:
-                cephMaintenance:
-                  enabled: false
-              installNamespaces: false
     ~~~
 doc_link: https://www.mirantis.com/software/ceph/
 show_install_tab: true

--- a/apps/ceph/example/Chart.yaml
+++ b/apps/ceph/example/Chart.yaml
@@ -3,6 +3,6 @@ name: example
 type: application
 version: 1.0.0
 dependencies:
-  - name: ceph-controller
-    version: 1.0.12
+  - name: pelagia-ceph
+    version: 1.0.0
     repository: oci://registry.mirantis.com/k0rdent-enterprise-catalog

--- a/apps/ceph/example/values.yaml
+++ b/apps/ceph/example/values.yaml
@@ -1,8 +1,4 @@
-ceph-controller:
-  ceph-operator:
-    rookExtraConfig:
+pelagia-ceph:
+  pelagia-ceph:
+    rookConfig:
       csiKubeletPath: /var/lib/k0s/kubelet
-    controllers:
-      cephMaintenance:
-        enabled: false
-    installNamespaces: false


### PR DESCRIPTION
Due to futher announce of pelagia - the upstream version of ceph-controller, change ceph-controller to pelagia in catalog.