### PR TITLE
pelagia: Update pelagia to the latest release 1.1.0

### DIFF
--- a/apps/ceph/data.yaml
+++ b/apps/ceph/data.yaml
@@ -27,7 +27,7 @@ support_link: https://www.mirantis.com/software/ceph/
 support_type: Enterprise
 charts:
   - name: pelagia-ceph
-    versions: ['1.0.0']
+    versions: ['1.1.0']
 deploy_code: |
     ~~~yaml
     apiVersion: k0rdent.mirantis.com/v1beta1
@@ -40,7 +40,7 @@ deploy_code: |
           group: demo
       serviceSpec:
         services:
-        - template: pelagia-1-0-0
+        - template: pelagia-1-1-0
           name: pelagia-ceph
           namespace: ceph-lcm-mirantis
           values: |

--- a/apps/ceph/example/Chart.yaml
+++ b/apps/ceph/example/Chart.yaml
@@ -4,5 +4,5 @@ type: application
 version: 1.0.0
 dependencies:
   - name: pelagia-ceph
-    version: 1.0.0
+    version: 1.1.0
     repository: oci://registry.mirantis.com/k0rdent-enterprise-catalog


### PR DESCRIPTION
We are happy to introduce a new stable release of pelagia ceph controller! It contains a few critical fixes and stabilization improvements. It is a first minor release after pelagia GA.