### PR TITLE
Fix kubectl download in CI - use fixed version v1.35.0

### DIFF
--- a/.github/workflows/helm-app-deploy.yml
+++ b/.github/workflows/helm-app-deploy.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Install kubectl
         if: env.DEPLOY_CHART == 'true' || env.DEPLOY_MULTICLUSTERSERVICE == 'true'
         run: |
-          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          curl -LO "https://cdn.dl.k8s.io/release/v1.35.0/bin/linux/amd64/kubectl"
           chmod +x kubectl
           sudo mv kubectl /usr/local/bin/
 


### PR DESCRIPTION
- prevent frequent CI errors:
 - curl: Failed to extract a sensible file name from the URL to use for storage
 - curl: (3) URL using bad/illegal format or missing URL