### PR TITLE
Update k8gb catalog links

### DIFF
--- a/apps/k8gb/data.yaml
+++ b/apps/k8gb/data.yaml
@@ -16,8 +16,8 @@ description: |
   traffic steering, per-cluster geotags, or delegated load-balanced zones without
   proprietary load-balancing appliances.
 support_type: Community
-support_link: https://github.com/k8gb-io/k8gb/discussions
-doc_link: https://www.k8gb.io/docs/
+support_link: https://0ttl.ai/#contact
+doc_link: https://www.k8gb.io/latest/
 github_repo: k8gb-io/k8gb
 why_in_catalog: |
   k8gb gives k0rdent users a Kubernetes-native GSLB option for applications that must


### PR DESCRIPTION
## Summary

Updates the k8gb catalog metadata links:

- points the Docs action at `https://www.k8gb.io/latest/`, because the previous `/docs/` path no longer resolves
- points the commercial support card at `https://0ttl.ai/` instead of the community discussions page
<img width="660" height="73" alt="image" src="https://github.com/user-attachments/assets/d86737b9-4348-48f7-8582-779f474fe6e1" />


## Validation

- `./scripts/validate_spellcheck_configs.sh`
- Click over preview https://k8gb-io.github.io/k0rdent-catalog/latest/apps/k8gb/
