### PR TITLE
ceph: update catalog with pelagia-ceph chart 1.7.0 version

### DIFF
--- a/apps/ceph/charts/charts.yaml
+++ b/apps/ceph/charts/charts.yaml
@@ -6,3 +6,5 @@ charts:
     appVersion: dev
   - version: 1.5.0
     appVersion: 1.5.0
+  - version: 1.7.0
+    appVersion: 1.7.0

--- a/apps/ceph/charts/st-charts.yaml
+++ b/apps/ceph/charts/st-charts.yaml
@@ -12,3 +12,7 @@ st-charts:
   dep_name: pelagia-ceph
   version: 1.5.0
   repository: oci://registry.mirantis.com/pelagia
+- name: pelagia-ceph
+  dep_name: pelagia-ceph
+  version: 1.7.0
+  repository: oci://registry.mirantis.com/pelagia

--- a/apps/ceph/example/Chart.yaml
+++ b/apps/ceph/example/Chart.yaml
@@ -4,5 +4,5 @@ type: application
 version: 1.0.0
 dependencies:
   - name: pelagia-ceph
-    version: 1.5.0
+    version: 1.7.0
     repository: oci://registry.mirantis.com/k0rdent-enterprise-catalog


### PR DESCRIPTION
Update pelagia-ceph chart to the latest actual version.