### PR TITLE
clearml: set support tier to Partner

### DIFF
--- a/apps/clearml/data.yaml
+++ b/apps/clearml/data.yaml
@@ -22,6 +22,7 @@ description: |
 
 why_in_catalog: "Reproducing a training run six months later is harder than it sounds when you cannot remember which dataset version, hyperparameter combination, and code commit produced the model in production. ClearML automatically captures all of that — metrics, artifacts, environment, and code state — for every experiment, without requiring engineers to instrument their training scripts beyond a two-line import. Its model registry and remote execution agents turn ad-hoc notebook experiments into a governed, auditable ML pipeline."
 support_link: https://clear.ml/contact-us
+support_type: Partner
 
 doc_link: https://clear.ml/docs/latest/docs/
 


### PR DESCRIPTION
## Summary
Sets ClearML's support tier to Partner. `apps/clearml/data.yaml` had no `support_type` field, so it was falling back to the `community` default used by `scripts/web/generate_index.py` and `scripts/web/generate_catalog_json.py`.

## Notes
- Only change is `support_type: Partner` in `apps/clearml/data.yaml`.
- No chart repository impact: `DEFAULT_CHART_REPOS` maps both `community` and `partner` to `oci://ghcr.io/k0rdent/catalog/charts`.
- Effect is on the catalog UI badge/filter (Community → Verified Partner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)