### PR TITLE
tsweb: add the "Become a partner" band from the new design

### DIFF
--- a/tsweb/src/components/App.tsx
+++ b/tsweb/src/components/App.tsx
@@ -11,6 +11,7 @@ import { SolutionsPage } from "./SolutionsPage";
 import { InfraPage } from "./InfraPage";
 import { ConfiguratorPage } from "./ConfiguratorPage";
 import { HowToPage } from "./HowToPage";
+import { PartnerCTA } from "./PartnerCTA";
 
 export default function App() {
   var initParams = useMemo(readUrlParams, []);
@@ -275,6 +276,8 @@ export default function App() {
           .k0-detail-aside { position: static !important; }
           .k0-detail-hero { padding: 20px 24px 36px !important; }
           .k0-footer { padding: 48px 24px !important; gap: 40px !important; }
+          .k0-partner { padding: 80px 24px 0 !important; }
+          .k0-partner-panel { padding: 48px 32px !important; gap: 32px !important; }
         }
         @media (max-width: 760px) {
           .k0-nav-inner { height: auto !important; flex-wrap: wrap; padding: 12px 16px !important; gap: 12px !important; row-gap: 10px !important; }
@@ -300,6 +303,11 @@ export default function App() {
           .k0-detail-tabs button { padding: 11px 14px 9px !important; font-size: 11px !important; }
           .k0-ver-row { grid-template-columns: 1fr auto !important; gap: 8px 16px !important; }
           .k0-footer { padding: 40px 16px !important; gap: 32px !important; }
+          .k0-partner { padding: 56px 16px 0 !important; }
+          .k0-partner-panel { padding: 32px 20px !important; gap: 24px !important; }
+          .k0-partner-copy { min-width: 0 !important; }
+          .k0-partner h2 { font-size: 28px !important; line-height: 32px !important; }
+          .k0-partner a { width: 100% !important; justify-content: center !important; }
           .k0-catalog-header { flex-direction: column !important; align-items: flex-start !important; gap: 8px !important; }
         }
         .anchor-link { color: ${B.textDim}; text-decoration: none; margin-left: 6px; opacity: 0; transition: opacity 0.15s; font-size: 0.8em; }
@@ -463,6 +471,11 @@ export default function App() {
         backLabel="Back to catalog"
         onOpenApp={function(next:any){ openApp(next); }}
         onBack={function(){ closeApp(); }}/>}
+
+      {/* Partner band rides above the footer on the index pages — not on an
+          application page, the contribute doc, the configurator or the tour. */}
+      {!selected&&view!=="contribute"&&view!=="configurator"&&view!=="howto"&&
+        <PartnerCTA href={appendTheme(versionBase(k0rdentVer||"")+"contribute/")} onContribute={function(){navigateTo("contribute");}}/>}
 
       <SiteFooter onNavigate={navigateTo}/>
     </div>

--- a/tsweb/src/components/PartnerCTA.tsx
+++ b/tsweb/src/components/PartnerCTA.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { B, GRAD } from '../constants';
+
+// "Become a partner" band — the last block above the footer on the index
+// pages (catalog, solutions, infrastructure). Hairline panel over a 104deg
+// wash, oversized headline, gradient primary CTA into the contribute page.
+export function PartnerCTA({ href, onContribute }:{ href:string, onContribute:()=>void }) {
+  return (
+    <section className="k0-partner" style={{maxWidth:1440,margin:"0 auto",padding:"120px 40px 0"}}>
+      <div className="k0-partner-panel" style={{border:"1px solid "+B.border,
+        background:"linear-gradient(104deg,"+B.bg0+" 25%,"+B.panelHi+" 100%)",
+        padding:"64px 56px",display:"flex",alignItems:"center",justifyContent:"space-between",
+        gap:56,flexWrap:"wrap"}}>
+        <div className="k0-partner-copy" style={{flex:1,minWidth:340,display:"flex",flexDirection:"column",gap:16}}>
+          <span style={{fontSize:14,fontWeight:800,textTransform:"uppercase",letterSpacing:"0.12em",color:B.textMut}}>For partners</span>
+          <h2 style={{margin:0,fontSize:40,lineHeight:"44px",fontWeight:700,color:B.textPri,maxWidth:"24ch",textWrap:"pretty"}}>
+            List your product where platform teams are already shopping.
+          </h2>
+          <p style={{margin:0,fontSize:16,lineHeight:"26px",color:B.textSec,maxWidth:"58ch"}}>
+            Ship a Helm chart and a ServiceTemplate manifest. Mirantis validates it against the current k0rdent release and publishes it as verified.
+          </p>
+        </div>
+        <a href={href} onClick={function(e:any){e.preventDefault();onContribute();}}
+          onMouseEnter={function(e:any){e.currentTarget.style.filter="brightness(1.08)";}}
+          onMouseLeave={function(e:any){e.currentTarget.style.filter="none";}}
+          style={{flex:"none",display:"inline-flex",alignItems:"center",padding:"18px 40px 14px",
+            border:"2px solid #000",borderRadius:40,background:GRAD,color:"#000",fontSize:14,fontWeight:900,
+            textTransform:"uppercase",letterSpacing:"0.06em",textDecoration:"none",
+            boxShadow:"0 4px 4px rgba(0,0,0,0.25)"}}>Become a partner</a>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Adds the partner band from the new catalog design as the last block above the site footer.

## What

A `PartnerCTA` section: hairline panel over a `104deg` wash, "For partners" eyebrow, 40px headline, the Helm chart / ServiceTemplate blurb, and a gradient CTA into the contribute page.

Structure and metrics follow the design mockup; its CSS vars map onto the brand tokens already in `constants.ts`, so the band themes light and dark:

| design | here |
| --- | --- |
| `--c-line` / `--c-bg` / `--c-panel3` | `B.border` / `B.bg0` / `B.panelHi` |
| `--c-fg3` / `--c-fg` / `--c-fg2` | `B.textMut` / `B.textPri` / `B.textSec` |
| `linear-gradient(90deg,#00FFF7,#00FFA0)` | `GRAD` |

Kept from the design as-is: the `64px 56px` panel padding, 14px/`0.12em` eyebrow, 40px/44px headline at `max-width:24ch`, 16px/26px lede at `58ch`, and the `2px solid #000` + shadow gradient pill with the `brightness(1.08)` hover that the other primary CTAs already use.

## Where it shows

Gated on `!selected && view!=="contribute" && view!=="configurator" && view!=="howto"` -- the design's `showPartner` rule. So it appears on Catalog, Solutions and Infrastructure, and stays off application pages, the contribute doc, the configurator and the How-to tour.

Responsive: `.k0-partner*` rules added to the existing 1080px and 760px blocks -- padding steps down, headline drops to 28px, CTA goes full-width.

## Testing

`tsc --noEmit` and `vite build` both clean on top of `main`. Not verified in a browser -- no browser in the authoring environment, and the dev server needs a generated `catalog.json`, so the band is worth an eyeball on a preview build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
